### PR TITLE
Give a "remove_levels" different than 1 when using config function

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -216,7 +216,7 @@ class ConfigurationSet(Configuration):
         return "<ConfigurationSet %r>" % self.as_dict()
 
 
-def config(*configs: Iterable, prefix: str = '') -> ConfigurationSet:
+def config(*configs: Iterable, prefix: str = '', remove_level: int = 1) -> ConfigurationSet:
     instances = []
     for config_ in configs:
         if isinstance(config_, dict):
@@ -266,7 +266,7 @@ def config(*configs: Iterable, prefix: str = '') -> ConfigurationSet:
         elif type_ == 'ini':
             instances.append(config_from_ini(*config_[1:]))
         elif type_ == 'path':
-            instances.append(config_from_path(*config_[1:]))
+            instances.append(config_from_path(*config_[1:], remove_level))
         else:
             raise ValueError('Unknown configuration type "%s"' % type_)
 


### PR DESCRIPTION
Hi Tiago !

Thanks for the library, it works great ! I'd like to add the possibility to remove levels when using config from path : 
```
configurations = list()
configurations.extend(args.config_paths)
configurations.extend(args.config_files)
confSet = config(*configurations, prefix="MY_PREFIX", remove_level=0)
```