### PR TITLE
Normalize path if it contains useless slash

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -284,6 +284,7 @@ def config_from_env(prefix: str, separator: str = '__') -> Configuration:
 
 
 def config_from_path(path: str, remove_level: int = 1) -> Configuration:
+    path = os.path.normpath(path)
     dotted_path_levels = len(path.split('/'))
     files_keys = (
         (os.path.join(x[0], y), '.'.join((x[0].split('/') + [y])[(dotted_path_levels + remove_level):]))

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -34,8 +34,33 @@ def _config_from_temp_path(dic, remove_level=0):  # type: ignore
     return cfg, folder, walk
 
 
+def _config_from_temp_path_with_trailing_slash(dic, remove_level=0):  # type: ignore
+    import os
+    with tempfile.TemporaryDirectory() as folder:
+        lvl = remove_level
+        subfolder = folder
+        while lvl > 0:
+            subfolder += '/sub'
+            os.makedirs(subfolder)
+            lvl -= 1
+        create_path_from_config(subfolder, config_from_dict(dic),
+                                remove_level=remove_level)
+        folder += '/'
+        cfg = config_from_path(folder, remove_level=remove_level)
+        walk = list(os.walk(folder))
+    return cfg, folder, walk
+
+
 def test_load_path():  # type: ignore
     cfg, folder, walk = _config_from_temp_path(DICT, remove_level=0)
+    assert set(walk[0][2]) == set(DICT.keys())
+    assert cfg["a1.b1"].get_int("c1") == 1
+    assert cfg["a1.b1"].as_dict() == {"c1": '1', "c2": '2', "c3": '3'}
+    assert cfg["a1.b2"].as_dict() == {"c1": "a", "c2": 'True', "c3": '1.1'}
+
+
+def test_load_path_with_trailing_slash():
+    cfg, folder, walk = _config_from_temp_path_with_trailing_slash(DICT, remove_level=0)
     assert set(walk[0][2]) == set(DICT.keys())
     assert cfg["a1.b1"].get_int("c1") == 1
     assert cfg["a1.b1"].as_dict() == {"c1": '1', "c2": '2', "c3": '3'}


### PR DESCRIPTION
If you call `config_from_path` with a path with a trailing slash (like `/run/secrets/`), the `dotted_path_levels` value is bad, so it is necessary to normalize the path.