### PR TITLE
Fix __getattr_ behavior

### DIFF
--- a/config/configuration.py
+++ b/config/configuration.py
@@ -163,7 +163,10 @@ class Configuration:
             return v
 
     def __getattr__(self, item: str) -> Any:  # noqa: D105
-        return self[item]
+        try:
+            return self[item]
+        except KeyError:
+            raise AttributeError(item)
 
     def get(self, key: str, default: Any = None) -> Union[dict, Any]:
         """


### PR DESCRIPTION
Per https://docs.python.org/3/reference/datamodel.html#object.__getattr__ 

"This method should either return the (computed) attribute value or raise an AttributeError exception."

The current behavior prevents configuration objects from pickling correctly.
