### PR TITLE
Allow for filtering sections by prefix in INI/toml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Added the `section_prefix` parameter that filters sections by prefix in INI/toml files
+
 ## [0.8.2] - 2021-01-30
 
 ### Fixed

--- a/tests/test_ini.py
+++ b/tests/test_ini.py
@@ -62,3 +62,51 @@ def test_reload():  # type: ignore
         cfg2 = config_from_dict(dict((k, str(v)) for k, v in DICT.items()))
         cfg2["section4.key10"] = "1"
         assert cfg == cfg2
+
+
+def test_reload_with_section_prefix():  # type: ignore
+    with tempfile.NamedTemporaryFile() as f:
+        INI = """
+        [coverage:run]
+        branch = False
+        parallel = False
+
+        [other:section1]
+        key1 = abc
+        key2 = def
+        key3 = 1.1
+
+        [section2]
+        key1 = 1
+        key2 = 0
+        """
+
+        f.file.write(INI.encode())
+        f.file.flush()
+        cfg = config_from_ini(
+            open(f.name, "rt"), section_prefix="coverage:", read_from_file=True
+        )
+
+        expected = config_from_dict(
+            {
+                "run.branch": "False",
+                "run.parallel": "False",
+            }
+        )
+
+        assert cfg == expected
+
+        f.file.write(b"\n[coverage:report]\nignore_errors = False\n")
+        f.file.flush()
+        cfg = config_from_ini(
+            open(f.name, "rt"), section_prefix="coverage:", read_from_file=True
+        )
+        cfg2 = config_from_dict(
+            {
+                "run.branch": "False",
+                "run.parallel": "False",
+                "report.ignore_errors": "False",
+            }
+        )
+
+        assert cfg == cfg2


### PR DESCRIPTION
Closes #54

Allows other libraries to use `python-configuration` to load their configurations from shared config files.