### PR TITLE
Fix/not lowercase keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 - Added the `section_prefix` parameter that filters sections by prefix in INI/toml files
 
+## [0.8.3] - 2021-10-11
+
+### Fixed
+
+- configurations from ini file won't be converted to lower case if `lowercase_keys = False`
+
 ## [0.8.2] - 2021-01-30
 
 ### Fixed

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -415,13 +415,19 @@ class INIConfiguration(FileConfiguration):
         """Reload the INI data."""
         import configparser
 
+        lowercase = self._lowercase
+
+        class ConfigParser(configparser.RawConfigParser):
+            def optionxform(self, optionstr: str) -> str:
+                return super().optionxform(optionstr) if lowercase else optionstr
+
         if read_from_file:
             if isinstance(data, str):
                 data = open(data, "rt").read()
             else:
                 data = data.read()
         data = cast(str, data)
-        cfg = configparser.RawConfigParser()
+        cfg = ConfigParser()
         cfg.read_string(data)
         result = {
             section[len(self._section_prefix) :] + "." + k: v

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -397,7 +397,7 @@ class INIConfiguration(FileConfiguration):
         data: Union[str, TextIO],
         read_from_file: bool = False,
         *,
-        section_prefix: str = '',
+        section_prefix: str = "",
         lowercase_keys: bool = False,
         interpolate: InterpolateType = False,
         interpolate_type: InterpolateEnumType = InterpolateEnumType.STANDARD,
@@ -408,7 +408,7 @@ class INIConfiguration(FileConfiguration):
             read_from_file=read_from_file,
             lowercase_keys=lowercase_keys,
             interpolate=interpolate,
-            interpolate_type=interpolate_type
+            interpolate_type=interpolate_type,
         )
 
     def _reload(self, data: Union[str, TextIO], read_from_file: bool = False) -> None:
@@ -424,7 +424,7 @@ class INIConfiguration(FileConfiguration):
         cfg = configparser.RawConfigParser()
         cfg.read_string(data)
         result = {
-            section[len(self._section_prefix):] + "." + k: v
+            section[len(self._section_prefix) :] + "." + k: v
             for section, values in cfg.items()
             for k, v in values.items()
             if section.startswith(self._section_prefix)
@@ -694,12 +694,13 @@ if toml is not None:  # pragma: no branch
 
     class TOMLConfiguration(FileConfiguration):
         """Configuration from a TOML input."""
+
         def __init__(
             self,
             data: Union[str, TextIO],
             read_from_file: bool = False,
             *,
-            section_prefix: str = '',
+            section_prefix: str = "",
             lowercase_keys: bool = False,
             interpolate: InterpolateType = False,
             interpolate_type: InterpolateEnumType = InterpolateEnumType.STANDARD,
@@ -710,7 +711,7 @@ if toml is not None:  # pragma: no branch
                 read_from_file=read_from_file,
                 lowercase_keys=lowercase_keys,
                 interpolate=interpolate,
-                interpolate_type=interpolate_type
+                interpolate_type=interpolate_type,
             )
 
         def _reload(
@@ -728,7 +729,7 @@ if toml is not None:  # pragma: no branch
             loaded = cast(dict, loaded)
 
             result = {
-                k[len(self._section_prefix):]: v
+                k[len(self._section_prefix) :]: v
                 for k, v in self._flatten_dict(loaded).items()
                 if k.startswith(self._section_prefix)
             }
@@ -739,7 +740,7 @@ if toml is not None:  # pragma: no branch
         data: Union[str, TextIO],
         read_from_file: bool = False,
         *,
-        section_prefix: str = '',
+        section_prefix: str = "",
         lowercase_keys: bool = False,
         interpolate: InterpolateType = False,
         interpolate_type: InterpolateEnumType = InterpolateEnumType.STANDARD,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "python-configuration"
 packages = [{ include = "config" }]
 readme = 'README.md'
 repository = "https://github.com/tr11/python-configuration"
-version = "0.8.2"
+version = "0.8.3"
 
 [tool.poetry.dependencies]
 azure-identity = { version = "^1.5.0", optional = true }

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -57,7 +57,7 @@ def test_attribute_dict_1():  # type: ignore
     assert d.var3 == "abc"
 
 
-def test_tuple():
+def test_tuple():  # type: ignore
     DICT = {"a1": (1, 2)}
     cfg = config_from_dict(DICT, interpolate=True)
     assert cfg["a1"] == (1, 2)


### PR DESCRIPTION
In this PR you'll find couple minor fixes to pass tests & fix for keys in ini files.

example.ini:
```
[section]
iAmCamelCaseKey = 'true'
```

Previous behaviour:
```python
configs = config('example.ini', lowercase_keys=False)
assert 'iamcamelcasekey' in configs.section
```

Current behaviour:
```python
configs = config('example.ini', lowercase_keys=False)
assert 'iAmCamelCaseKey' in configs.section
```