### PR TITLE
Use valid Azure tenant characters in tests

### DIFF
--- a/tests/contrib/test_azure.py
+++ b/tests/contrib/test_azure.py
@@ -51,7 +51,7 @@ class FakeSecretClient:
 @pytest.mark.skipif("azure is None")
 def test_load_dict():  # type: ignore
     cfg = AzureKeyVaultConfiguration(
-        "fake_id", "fake_secret", "fake_tenant", "fake_vault"
+        "fake_id", "fake_secret", "fake-tenant", "fake_vault"
     )
     cfg._kv_client = FakeSecretClient(DICT)
     assert cfg["foo"] == "foo_val"
@@ -63,7 +63,7 @@ def test_load_dict():  # type: ignore
 def test_expiration(mocker):  # type: ignore
     # with cache
     cfg = AzureKeyVaultConfiguration(
-        "fake_id", "fake_secret", "fake_tenant", "fake_vault"
+        "fake_id", "fake_secret", "fake-tenant", "fake_vault"
     )
     cfg._kv_client = FakeSecretClient(DICT)
 
@@ -74,7 +74,7 @@ def test_expiration(mocker):  # type: ignore
 
     # without cache
     cfg = AzureKeyVaultConfiguration(
-        "fake_id", "fake_secret", "fake_tenant", "fake_vault", cache_expiration=0
+        "fake_id", "fake_secret", "fake-tenant", "fake_vault", cache_expiration=0
     )
     cfg._kv_client = FakeSecretClient(DICT)
 
@@ -87,7 +87,7 @@ def test_expiration(mocker):  # type: ignore
 @pytest.mark.skipif("azure is None")
 def test_deletion():  # type: ignore
     cfg = AzureKeyVaultConfiguration(
-        "fake_id", "fake_secret", "fake_tenant", "fake_vault", cache_expiration=0
+        "fake_id", "fake_secret", "fake-tenant", "fake_vault", cache_expiration=0
     )
     d = DICT.copy()
     cfg._kv_client = FakeSecretClient(d)
@@ -103,7 +103,7 @@ def test_deletion():  # type: ignore
 @pytest.mark.skipif("azure is None")
 def test_missing_key():  # type: ignore
     cfg = AzureKeyVaultConfiguration(
-        "fake_id", "fake_secret", "fake_tenant", "fake_vault", cache_expiration=0
+        "fake_id", "fake_secret", "fake-tenant", "fake_vault", cache_expiration=0
     )
     d = DICT.copy()
     cfg._kv_client = FakeSecretClient(d)
@@ -117,7 +117,7 @@ def test_missing_key():  # type: ignore
 @pytest.mark.skipif("azure is None")
 def test_get_attr():  # type: ignore
     cfg = AzureKeyVaultConfiguration(
-        "fake_id", "fake_secret", "fake_tenant", "fake_vault", cache_expiration=0
+        "fake_id", "fake_secret", "fake-tenant", "fake_vault", cache_expiration=0
     )
     d = DICT.copy()
     cfg._kv_client = FakeSecretClient(d)
@@ -131,7 +131,7 @@ def test_get_attr():  # type: ignore
 @pytest.mark.skipif("azure is None")
 def test_dict():  # type: ignore
     cfg = AzureKeyVaultConfiguration(
-        "fake_id", "fake_secret", "fake_tenant", "fake_vault", cache_expiration=0
+        "fake_id", "fake_secret", "fake-tenant", "fake_vault", cache_expiration=0
     )
     d = DICT.copy()
     cfg._kv_client = FakeSecretClient(d)
@@ -144,7 +144,7 @@ def test_dict():  # type: ignore
 @pytest.mark.skipif("azure is None")
 def test_repr():  # type: ignore
     cfg = AzureKeyVaultConfiguration(
-        "fake_id", "fake_secret", "fake_tenant", "fake_vault", cache_expiration=0
+        "fake_id", "fake_secret", "fake-tenant", "fake_vault", cache_expiration=0
     )
     d = DICT.copy()
     cfg._kv_client = FakeSecretClient(d)
@@ -155,7 +155,7 @@ def test_repr():  # type: ignore
 @pytest.mark.skipif("azure is None")
 def test_str():  # type: ignore
     cfg = AzureKeyVaultConfiguration(
-        "fake_id", "fake_secret", "fake_tenant", "fake_vault", cache_expiration=0
+        "fake_id", "fake_secret", "fake-tenant", "fake_vault", cache_expiration=0
     )
     d = DICT.copy()
     cfg._kv_client = FakeSecretClient(d)
@@ -171,7 +171,7 @@ def test_str():  # type: ignore
 @pytest.mark.skipif("azure is None")
 def test_reload():  # type: ignore
     cfg = AzureKeyVaultConfiguration(
-        "fake_id", "fake_secret", "fake_tenant", "fake_vault"
+        "fake_id", "fake_secret", "fake-tenant", "fake_vault"
     )
     cfg._kv_client = FakeSecretClient(DICT)
     assert cfg == config_from_dict(DICT)


### PR DESCRIPTION
### What are you trying to accomplish?

The `test_azure.py` tests are failing due to new validation in the `azure` dependency.

[Version 1.5.0](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity/CHANGELOG.md#150-2020-11-11) added validation of the characters use in tenant IDs.

Ref: https://github.com/Azure/azure-sdk-for-python/pull/14955

### What approach did you choose and why?

This PR simply changes the tests to only use valid tenant ID characters in the test tenant id.

### What should reviewers focus on?

🤷 

### The impact of these changes

Tests pass again. No impact on functionality.