### PR TITLE
Use f-strings for format strings

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -83,7 +83,7 @@ def config(
             elif all(s and s.isidentifier() for s in config_.split(".")):
                 config_ = ("python", config_, *default_args)
             else:
-                raise ValueError('Cannot determine config type from "%s"' % config_)
+                raise ValueError(f'Cannot determine config type from "{config_}"')
 
         if not isinstance(config_, (tuple, list)) or len(config_) == 0:
             raise ValueError(
@@ -142,7 +142,7 @@ def config(
                 if not ignore_missing_paths:
                     raise
         else:
-            raise ValueError('Unknown configuration type "%s"' % type_)
+            raise ValueError(f'Unknown configuration type "{type_}"')
 
     return ConfigurationSet(
         *instances, interpolate=interpolate, interpolate_type=interpolate_type

--- a/config/contrib/azure.py
+++ b/config/contrib/azure.py
@@ -55,9 +55,7 @@ class AzureKeyVaultConfiguration(Configuration):
             client_secret=az_client_secret,
             tenant_id=az_tenant_id,
         )
-        vault_url = "https://{az_vault_name}.vault.azure.net/".format(
-            az_vault_name=az_vault_name
-        )
+        vault_url = f"https://{az_vault_name}.vault.azure.net/"
         self._kv_client = SecretClient(vault_url=vault_url, credential=credentials)
         self._cache_expiration = cache_expiration
         self._cache: Dict[str, Cache] = {}
@@ -148,7 +146,7 @@ class AzureKeyVaultConfiguration(Configuration):
         self._cache.clear()
 
     def __repr__(self) -> str:  # noqa: D105
-        return "<AzureKeyVaultConfiguration: %r>" % self._kv_client.vault_url
+        return f"<AzureKeyVaultConfiguration: {repr(self._kv_client.vault_url)}>"
 
     @property
     def _config(self) -> Dict[str, Any]:  # type: ignore


### PR DESCRIPTION
f-strings were added in Python 3.6, and are the preferred way to do format strings.

Since `python-configuration` support Python 3.6+, we can make use of them 🎉

(Indeed, other format strings in the files are already using them)

No impact on functionality. Just a small cleanup.