### PR TITLE
Use tomllib over toml for Python 3.11+

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -3,6 +3,7 @@
 import json
 import os
 from importlib.abc import InspectLoader
+import sys
 from types import ModuleType
 from typing import Any, Dict, Iterable, List, Mapping, Optional, TextIO, Union, cast
 
@@ -10,10 +11,19 @@ try:
     import yaml
 except ImportError:  # pragma: no cover
     yaml = None
-try:
-    import toml
-except ImportError:  # pragma: no cover
-    toml = None
+
+if sys.version_info[1] < 11:
+    try:
+        import toml  # type: ignore [no-redef,unused-ignore]
+
+        toml_readtype = "rt"
+    except ImportError:  # pragma: no cover
+        toml = None  # type: ignore [assignment,unused-ignore]
+        toml_readtype = ""
+else:
+    import tomllib as toml  # type: ignore [import-not-found,unused-ignore]
+
+    toml_readtype = "rb"
 
 
 from .configuration import Configuration
@@ -861,10 +871,10 @@ class TOMLConfiguration(FileConfiguration):
         """Reload the TOML data."""
         if read_from_file:
             if isinstance(data, str):
-                with open(data, "rt") as f:
+                with open(data, toml_readtype) as f:
                     loaded = toml.load(f)
             else:
-                loaded = toml.load(data)
+                loaded = toml.load(data)  # type: ignore [arg-type,unused-ignore]
         else:
             data = cast(str, data)
             loaded = toml.loads(data)

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -2,8 +2,8 @@
 
 import json
 import os
-from importlib.abc import InspectLoader
 import sys
+from importlib.abc import InspectLoader
 from types import ModuleType
 from typing import Any, Dict, Iterable, List, Mapping, Optional, TextIO, Union, cast
 
@@ -14,14 +14,14 @@ except ImportError:  # pragma: no cover
 
 if sys.version_info[1] < 11:
     try:
-        import toml  # type: ignore [no-redef,unused-ignore]
+        import toml
 
         toml_readtype = "rt"
     except ImportError:  # pragma: no cover
-        toml = None  # type: ignore [assignment,unused-ignore]
+        toml = None
         toml_readtype = ""
 else:
-    import tomllib as toml  # type: ignore [import-not-found,unused-ignore]
+    import tomllib as toml
 
     toml_readtype = "rb"
 

--- a/tests/contrib/test_azure.py
+++ b/tests/contrib/test_azure.py
@@ -42,7 +42,7 @@ class FakeSecretClient:
         if key in self._dict:
             return FakeKeySecret(key, self._dict[key])
         else:
-            raise ResourceNotFoundError()  # type: ignore
+            raise ResourceNotFoundError()
 
     def list_properties_of_secrets(self) -> list:
         return [Secret(name=k, value=v) for k, v in self._dict.items()]

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -1,9 +1,12 @@
-import pytest
-from config import config_from_dict
 import tempfile
+
+import pytest
+
+from config import config_from_dict
 
 try:
     import toml
+
     from config import config_from_toml
 except ImportError:
     toml = None
@@ -75,7 +78,16 @@ def test_load_toml_file():  # type: ignore
     with tempfile.NamedTemporaryFile() as f:
         f.file.write(TOML.encode())
         f.file.flush()
-        cfg = config_from_toml(open(f.name, "rt"), read_from_file=True)
+
+        # Two different toml libraries are in use
+        import sys
+
+        if sys.version_info[1] < 11:
+            read_type = "rt"
+        else:
+            read_type = "rb"
+
+        cfg = config_from_toml(open(f.name, read_type), read_from_file=True)
     assert cfg["a1.b1.c1"] == 1
     assert cfg["a1.b1"].as_dict() == {"c1": 1, "c2": 2, "c3": 3}
     assert cfg["a1.b2"].as_dict() == {"c1": "a", "c2": True, "c3": 1.1}
@@ -132,13 +144,15 @@ ports = [ 8001, 8001, 8002,]
         f.file.flush()
 
         cfg = config_from_toml(
-            f.name, section_prefix="tool.coverage.", read_from_file=True
+            f.name,
+            section_prefix="tool.coverage.",
+            read_from_file=True,
         )
         expected = config_from_dict(
             {
                 "run.branch": False,
                 "run.parallel": False,
-            }
+            },
         )
 
         assert cfg == expected
@@ -151,6 +165,6 @@ ports = [ 8001, 8001, 8002,]
         expected = config_from_dict(
             {
                 "report.ignore_errors": False,
-            }
+            },
         )
         assert cfg == expected


### PR DESCRIPTION
The uiri toml implementation doesn't support some minor features of TOML, such as "Not a homogeneous array".

Given that tomllib is added to Python's stdlib, and supports the above feature, it should be loaded by default, and uiri's toml lib should be loaded as a backup